### PR TITLE
Adopt StackExchange.Redis APIs for local cache storage

### DIFF
--- a/src/DistributedCache.Api/DistributedCache.Api.csproj
+++ b/src/DistributedCache.Api/DistributedCache.Api.csproj
@@ -4,6 +4,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.8" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.58" />
   </ItemGroup>
 </Project>

--- a/src/DistributedCache.Api/Program.cs
+++ b/src/DistributedCache.Api/Program.cs
@@ -1,6 +1,6 @@
 using DistributedCache.Api.Models;
 using DistributedCache.Api.Services;
-using Microsoft.Extensions.Caching.StackExchangeRedis;
+using StackExchange.Redis;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,17 +14,10 @@ builder.Services
 var redisConnectionString = builder.Configuration.GetConnectionString("Redis");
 if (!string.IsNullOrWhiteSpace(redisConnectionString))
 {
-    builder.Services.AddStackExchangeRedisCache(options =>
-    {
-        options.Configuration = redisConnectionString;
-        options.InstanceName = "distributed-cache";
-    });
-}
-else
-{
-    builder.Services.AddDistributedMemoryCache();
+    builder.Services.AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect(redisConnectionString));
 }
 
+builder.Services.AddMemoryCache();
 builder.Services.AddHttpClient(nameof(PeerNodeClient));
 builder.Services.AddSingleton<ILocalCacheStore, LocalCacheStore>();
 builder.Services.AddSingleton<IPeerNodeClient, PeerNodeClient>();

--- a/src/DistributedCache.Api/Services/LocalCacheStore.cs
+++ b/src/DistributedCache.Api/Services/LocalCacheStore.cs
@@ -1,51 +1,90 @@
 using DistributedCache.Api.Models;
-using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using StackExchange.Redis;
 
 namespace DistributedCache.Api.Services;
 
-public sealed class LocalCacheStore(
-    IDistributedCache cache,
-    IConfiguration configuration,
-    IHostEnvironment hostEnvironment,
-    ILogger<LocalCacheStore> logger) : ILocalCacheStore
+public sealed class LocalCacheStore : ILocalCacheStore
 {
-    private readonly string _nodeId = configuration[$"{CacheClusterOptions.SectionName}:NodeId"]
-                                      ?? hostEnvironment.ApplicationName;
+    private const string KeyPrefix = "distributed-cache:";
+
+    private readonly string _nodeId;
+    private readonly IMemoryCache _memoryCache;
+    private readonly IDatabase? _redisDatabase;
+    private readonly ILogger<LocalCacheStore> _logger;
+
+    public LocalCacheStore(
+        IMemoryCache memoryCache,
+        IConfiguration configuration,
+        IHostEnvironment hostEnvironment,
+        ILogger<LocalCacheStore> logger,
+        IConnectionMultiplexer? redisConnection = null)
+    {
+        _memoryCache = memoryCache;
+        _logger = logger;
+        _nodeId = configuration[$"{CacheClusterOptions.SectionName}:NodeId"]
+                  ?? hostEnvironment.ApplicationName;
+        _redisDatabase = redisConnection?.GetDatabase();
+    }
 
     public async Task SetAsync(string key, string value, TimeSpan? ttl, CancellationToken cancellationToken)
     {
-        var options = new DistributedCacheEntryOptions();
+        if (_redisDatabase is not null)
+        {
+            await _redisDatabase.StringSetAsync(NormalizeKey(key), value, ttl);
+            return;
+        }
 
+        var options = new MemoryCacheEntryOptions();
         if (ttl is { } expiration)
         {
             options.AbsoluteExpirationRelativeToNow = expiration;
         }
 
-        await cache.SetStringAsync(key, value, options, cancellationToken);
+        _memoryCache.Set(key, value, options);
+        await Task.CompletedTask;
     }
 
     public async Task<CacheReadResult?> GetAsync(string key, CancellationToken cancellationToken)
     {
-        var value = await cache.GetStringAsync(key, cancellationToken);
-        if (value is null)
+        if (_redisDatabase is not null)
+        {
+            var value = await _redisDatabase.StringGetAsync(NormalizeKey(key));
+            if (!value.HasValue)
+            {
+                return null;
+            }
+
+            return new CacheReadResult(key, value.ToString(), _nodeId, IsLocal: true);
+        }
+
+        if (!_memoryCache.TryGetValue<string>(key, out var memoryValue) || memoryValue is null)
         {
             return null;
         }
 
-        return new CacheReadResult(key, value, _nodeId, IsLocal: true);
+        return new CacheReadResult(key, memoryValue, _nodeId, IsLocal: true);
     }
 
     public async Task<bool> DeleteAsync(string key, CancellationToken cancellationToken)
     {
         try
         {
-            await cache.RemoveAsync(key, cancellationToken);
-            return true;
+            if (_redisDatabase is not null)
+            {
+                return await _redisDatabase.KeyDeleteAsync(NormalizeKey(key));
+            }
+
+            _memoryCache.Remove(key);
+            return await Task.FromResult(true);
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to remove cache key {Key}", key);
+            _logger.LogWarning(ex, "Failed to remove cache key {Key}", key);
             return false;
         }
     }
+
+    private static RedisKey NormalizeKey(string key)
+        => (RedisKey)$"{KeyPrefix}{key}";
 }


### PR DESCRIPTION
### Motivation
- Replace the ASP.NET Redis cache wrapper with the official `StackExchange.Redis` client so the code uses the library's native APIs for cache operations. 
- Preserve an in-process memory fallback and wire up DI so a running Redis connection is used when configured while keeping behavior unchanged when Redis is absent.

### Description
- Replaced package reference `Microsoft.Extensions.Caching.StackExchangeRedis` with `StackExchange.Redis` in `src/DistributedCache.Api/DistributedCache.Api.csproj`.
- Updated `Program.cs` to register an `IConnectionMultiplexer` via `ConnectionMultiplexer.Connect(...)` when `ConnectionStrings:Redis` is present and to register `AddMemoryCache()` as the in-process fallback.
- Reworked `LocalCacheStore` to depend on `IMemoryCache` and an optional `IConnectionMultiplexer`, and to use `IDatabase.StringSetAsync`, `StringGetAsync`, and `KeyDeleteAsync` (with a `distributed-cache:` key prefix) when Redis is available, falling back to `IMemoryCache` otherwise.
- Kept existing endpoints and the coordinator logic unchanged while adjusting logging and method signatures to match the new implementation.

### Testing
- Ran `dotnet test` in the workspace which failed to run because the .NET SDK is not available in this environment (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f30dd5f08324b7aabc69288036d0)