### PR TITLE
Add reusable caching framework library

### DIFF
--- a/Caching.sln
+++ b/Caching.sln
@@ -2,6 +2,10 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Caching.Framework", "src\Caching.Framework\Caching.Framework.csproj", "{A1231FB8-9501-4D02-BDF2-67268D02D8ED}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Caching.Framework.Tests", "tests\Caching.Framework.Tests\Caching.Framework.Tests.csproj", "{F6B01F6B-3C8B-4130-8B1A-4106244F409E}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DistributedCache.Api", "src\DistributedCache.Api\DistributedCache.Api.csproj", "{9D2AA117-E179-42C2-A2E4-20D2F05B4B9A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DistributedCache.Api.Tests", "tests\DistributedCache.Api.Tests\DistributedCache.Api.Tests.csproj", "{8CF947D5-011A-4C1C-B33D-8F1319D4D2E0}"
@@ -12,6 +16,14 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1231FB8-9501-4D02-BDF2-67268D02D8ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1231FB8-9501-4D02-BDF2-67268D02D8ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1231FB8-9501-4D02-BDF2-67268D02D8ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1231FB8-9501-4D02-BDF2-67268D02D8ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6B01F6B-3C8B-4130-8B1A-4106244F409E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6B01F6B-3C8B-4130-8B1A-4106244F409E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6B01F6B-3C8B-4130-8B1A-4106244F409E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6B01F6B-3C8B-4130-8B1A-4106244F409E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9D2AA117-E179-42C2-A2E4-20D2F05B4B9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9D2AA117-E179-42C2-A2E4-20D2F05B4B9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9D2AA117-E179-42C2-A2E4-20D2F05B4B9A}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -1,0 +1,119 @@
+# Packaging and distributing Caching.Framework
+
+This guide explains how to build a NuGet package from this repository and share it with another team, customer, or partner.
+
+## Prerequisites
+
+- Install the .NET 8 SDK or later.
+- Run commands from the repository root.
+- Decide whether you will distribute the package through a private NuGet feed, a local folder/feed, or a direct `.nupkg` file transfer.
+
+## 1. Restore, build, and test
+
+```bash
+dotnet restore Caching.sln
+dotnet build Caching.sln -c Release --no-restore
+dotnet test Caching.sln -c Release --no-build
+```
+
+## 2. Create the NuGet package
+
+```bash
+dotnet pack src/Caching.Framework/Caching.Framework.csproj -c Release -o ./artifacts/packages
+```
+
+The output will be a package similar to:
+
+```text
+artifacts/packages/Caching.Framework.1.0.0.nupkg
+```
+
+## 3. Choose a distribution option
+
+### Option A: Private NuGet feed
+
+Use this when you want versioning, access control, and an easy update path.
+
+Examples include GitHub Packages, Azure Artifacts, ProGet, Nexus, Artifactory, or a private NuGet.org organization feed.
+
+```bash
+dotnet nuget push ./artifacts/packages/Caching.Framework.1.0.0.nupkg \
+  --source <PRIVATE_FEED_URL> \
+  --api-key <API_KEY>
+```
+
+The consuming party adds your feed and installs the package:
+
+```bash
+dotnet nuget add source <PRIVATE_FEED_URL> --name YourCompanyCacheFeed
+dotnet add package Caching.Framework --version 1.0.0
+```
+
+### Option B: Local folder feed
+
+Use this for pilots, offline delivery, or customer environments without hosted package infrastructure.
+
+Create a folder that contains the `.nupkg` file and give the folder to the consuming party. They can add it as a NuGet source:
+
+```bash
+dotnet nuget add source /path/to/packages --name LocalCachingFrameworkFeed
+dotnet add package Caching.Framework --version 1.0.0
+```
+
+### Option C: Direct `.nupkg` transfer
+
+Use this only for a one-off evaluation. Send the `.nupkg` file plus this repository's README and license terms. The recipient can install it by first adding the containing folder as a local feed.
+
+## 4. Version future releases
+
+Set the package version at pack time:
+
+```bash
+dotnet pack src/Caching.Framework/Caching.Framework.csproj \
+  -c Release \
+  -o ./artifacts/packages \
+  -p:PackageVersion=1.1.0
+```
+
+Recommended versioning pattern:
+
+- Patch, such as `1.0.1`, for bug fixes.
+- Minor, such as `1.1.0`, for backward-compatible features.
+- Major, such as `2.0.0`, for breaking changes.
+
+## 5. What to give external parties
+
+For a professional delivery, provide:
+
+- The `.nupkg` file or private feed URL.
+- Package version and release notes.
+- README usage examples.
+- License and commercial terms.
+- Supported .NET versions.
+- Contact/support process.
+
+## 6. Consumer usage example
+
+After installation, consuming applications can register the framework with dependency injection:
+
+```csharp
+using Caching.Framework.DependencyInjection;
+
+builder.Services.AddCachingFramework();
+```
+
+Then inject `ICacheClient` where caching is needed:
+
+```csharp
+using Caching.Framework.Abstractions;
+
+public sealed class ProductService(ICacheClient cache)
+{
+    public Task<Product> GetAsync(string sku, CancellationToken cancellationToken) =>
+        cache.GetOrCreateAsync(
+            $"product:{sku}",
+            token => LoadFromDatabaseAsync(sku, token),
+            CacheEntryOptions.WithTtl(TimeSpan.FromMinutes(10)),
+            cancellationToken);
+}
+```

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ public sealed class CatalogService(ICacheClient cache)
 ## Package for distribution
 
 ```bash
-dotnet pack src/Caching.Framework/Caching.Framework.csproj -c Release
+dotnet pack src/Caching.Framework/Caching.Framework.csproj -c Release -o ./artifacts/packages
 ```
 
-The project includes NuGet metadata so the generated package can be published to a private feed or marketplace after you add your final license, branding, documentation site, and support policy.
+The project includes NuGet metadata so the generated package can be published to a private feed or marketplace after you add your final license, branding, documentation site, and support policy. See [PACKAGING.md](PACKAGING.md) for step-by-step instructions for private feeds, local folder feeds, direct `.nupkg` delivery, versioning, and consumer setup.
 
 ## Roadmap for commercial hardening
 

--- a/README.md
+++ b/README.md
@@ -1,73 +1,73 @@
-# Distributed Cache Service
+# Caching Framework
 
-A production-style distributed cache API built with ASP.NET Core. It uses **Rendezvous Hashing** to shard keys across cache peers and replicates writes for resilience.
+A reusable .NET caching library designed to be packaged, licensed, and extended as a commercial caching framework.
 
-## Features
+## What is included
 
-- REST API for set/get/delete cache entries.
-- Rendezvous hashing for deterministic key placement.
-- Configurable replication factor.
-- Optional Redis-backed local store with in-memory fallback.
-- Peer-aware reads with automatic failover.
-- Unit tests for hashing and replication behavior.
+- `ICacheClient`: a small application-facing abstraction for `Set`, `Get`, `GetOrCreate`, and `Remove` workflows.
+- `MemoryCacheClient`: a production-ready in-process provider backed by `Microsoft.Extensions.Caching.Memory`.
+- Region-aware keys for tenant, module, or bounded-context separation.
+- Per-entry TTL support with cache hit metadata.
+- Rendezvous-hash placement primitives for distributed cache providers.
+- Dependency injection registration through `AddCachingFramework`.
+- Tests covering cache-aside behavior, regions, and deterministic distributed placement.
 
-## Quick start
+## Install from source
 
 ```bash
 dotnet restore
-dotnet run --project src/DistributedCache.Api
+dotnet build Caching.sln
 ```
 
-Set peers and local node ID using environment variables:
+## Register the framework
 
-- `CacheCluster__NodeId=node-a`
-- `CacheCluster__Peers__0=node-a=http://localhost:8080`
-- `CacheCluster__Peers__1=node-b=http://localhost:8081`
-- `CacheCluster__ReplicationFactor=2`
-- `ConnectionStrings__Redis=localhost:6379` (optional)
+```csharp
+using Caching.Framework.DependencyInjection;
+using Caching.Framework.Distributed;
 
-## Web demo
-
-The API now serves a browser-based dashboard at `/` that demonstrates the Redis calls already implemented in this repo:
-
-- `ConnectionMultiplexer.Connect`
-- `IDatabase.StringSetAsync`
-- `IDatabase.StringGetAsync`
-- `IDatabase.KeyDeleteAsync`
-
-From the dashboard you can:
-
-- Write values with an optional TTL.
-- Read and delete cache entries.
-- Inspect rendezvous-hash placement for a key.
-- View which owner replicas currently hold the value.
-- See whether the node is running against Redis or the in-memory fallback.
-
-For the full cluster demo, start the compose stack and open any node in the browser:
-
-```bash
-docker compose up --build
-```
-
-- `http://localhost:8080`
-- `http://localhost:8081`
-- `http://localhost:8082`
-
-## API
-
-- `PUT /cache/{key}`
-- `GET /cache/{key}`
-- `DELETE /cache/{key}`
-- `GET /cluster/placement/{key}`
-- `GET /demo/api/overview`
-- `GET /demo/api/inspect/{key}`
-- `GET /health/live`
-
-Payload for PUT:
-
-```json
+builder.Services.AddCachingFramework(options =>
 {
-  "value": "any string payload",
-  "ttlSeconds": 60
+    options.LocalNodeId = "node-a";
+    options.ReplicationFactor = 2;
+    options.Nodes =
+    [
+        new CacheNode("node-a", new Uri("https://cache-a.internal")),
+        new CacheNode("node-b", new Uri("https://cache-b.internal"))
+    ];
+});
+```
+
+## Use cache-aside in application code
+
+```csharp
+using Caching.Framework.Abstractions;
+
+public sealed class CatalogService(ICacheClient cache)
+{
+    public Task<Product> GetProductAsync(string sku, CancellationToken cancellationToken) =>
+        cache.GetOrCreateAsync(
+            $"product:{sku}",
+            token => LoadProductAsync(sku, token),
+            new CacheEntryOptions
+            {
+                Region = "catalog",
+                TimeToLive = TimeSpan.FromMinutes(10)
+            },
+            cancellationToken);
 }
 ```
+
+## Package for distribution
+
+```bash
+dotnet pack src/Caching.Framework/Caching.Framework.csproj -c Release
+```
+
+The project includes NuGet metadata so the generated package can be published to a private feed or marketplace after you add your final license, branding, documentation site, and support policy.
+
+## Roadmap for commercial hardening
+
+- Add Redis, SQL, and cloud cache provider packages that implement `ICacheClient`.
+- Add encryption, compression, stampede protection, metrics, and health checks.
+- Add signed packages and source-link metadata.
+- Add benchmarks and compatibility tests for supported .NET versions.

--- a/src/Caching.Framework/Abstractions/CacheEntryOptions.cs
+++ b/src/Caching.Framework/Abstractions/CacheEntryOptions.cs
@@ -1,0 +1,11 @@
+namespace Caching.Framework.Abstractions;
+
+/// <summary>Options for a single cache write.</summary>
+public sealed record CacheEntryOptions
+{
+    public TimeSpan? TimeToLive { get; init; }
+    public string? Region { get; init; }
+
+    public static CacheEntryOptions NeverExpire { get; } = new();
+    public static CacheEntryOptions WithTtl(TimeSpan ttl) => new() { TimeToLive = ttl };
+}

--- a/src/Caching.Framework/Abstractions/CacheItem.cs
+++ b/src/Caching.Framework/Abstractions/CacheItem.cs
@@ -1,0 +1,4 @@
+namespace Caching.Framework.Abstractions;
+
+/// <summary>Represents a cache hit and its metadata.</summary>
+public sealed record CacheItem<T>(string Key, T Value, DateTimeOffset? ExpiresAt = null, string? Region = null);

--- a/src/Caching.Framework/Abstractions/ICacheClient.cs
+++ b/src/Caching.Framework/Abstractions/ICacheClient.cs
@@ -1,0 +1,10 @@
+namespace Caching.Framework.Abstractions;
+
+/// <summary>Application-facing cache API used by framework consumers.</summary>
+public interface ICacheClient
+{
+    Task SetAsync<T>(string key, T value, CacheEntryOptions? options = null, CancellationToken cancellationToken = default);
+    Task<CacheItem<T>?> GetAsync<T>(string key, string? region = null, CancellationToken cancellationToken = default);
+    Task<T> GetOrCreateAsync<T>(string key, Func<CancellationToken, Task<T>> factory, CacheEntryOptions? options = null, CancellationToken cancellationToken = default);
+    Task<bool> RemoveAsync(string key, string? region = null, CancellationToken cancellationToken = default);
+}

--- a/src/Caching.Framework/Caching.Framework.csproj
+++ b/src/Caching.Framework/Caching.Framework.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <PackageId>Caching.Framework</PackageId>
+    <Title>Caching Framework</Title>
+    <Description>A composable .NET caching framework with in-memory storage, cache-aside helpers, and distributed rendezvous-hash placement.</Description>
+    <Authors>Caching Framework Contributors</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+</Project>

--- a/src/Caching.Framework/DependencyInjection/CachingFrameworkServiceCollectionExtensions.cs
+++ b/src/Caching.Framework/DependencyInjection/CachingFrameworkServiceCollectionExtensions.cs
@@ -1,0 +1,26 @@
+using Caching.Framework.Abstractions;
+using Caching.Framework.Distributed;
+using Caching.Framework.Memory;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Caching.Framework.DependencyInjection;
+
+public static class CachingFrameworkServiceCollectionExtensions
+{
+    public static IServiceCollection AddCachingFramework(this IServiceCollection services, Action<DistributedCacheOptions>? configureDistributed = null)
+    {
+        services.AddMemoryCache();
+        services.AddSingleton<ICacheClient, MemoryCacheClient>();
+        services.AddSingleton<CachePlacementService>();
+        if (configureDistributed is not null)
+        {
+            services.Configure(configureDistributed);
+        }
+        else
+        {
+            services.Configure<DistributedCacheOptions>(_ => { });
+        }
+
+        return services;
+    }
+}

--- a/src/Caching.Framework/Distributed/CacheNode.cs
+++ b/src/Caching.Framework/Distributed/CacheNode.cs
@@ -1,0 +1,4 @@
+namespace Caching.Framework.Distributed;
+
+/// <summary>A logical cache node available to the distributed placement engine.</summary>
+public sealed record CacheNode(string NodeId, Uri Endpoint);

--- a/src/Caching.Framework/Distributed/CachePlacementService.cs
+++ b/src/Caching.Framework/Distributed/CachePlacementService.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Options;
+
+namespace Caching.Framework.Distributed;
+
+/// <summary>Exposes deterministic owner selection for distributed cache implementations.</summary>
+public sealed class CachePlacementService
+{
+    private readonly DistributedCacheOptions _options;
+    private readonly RendezvousHashRing _ring;
+
+    public CachePlacementService(IOptions<DistributedCacheOptions> options)
+    {
+        _options = options.Value;
+        var nodes = _options.Nodes.Count > 0
+            ? _options.Nodes
+            : [new CacheNode(_options.LocalNodeId, new Uri("http://localhost"))];
+        _ring = new RendezvousHashRing(nodes);
+    }
+
+    public IReadOnlyList<CacheNode> GetOwners(string key) => _ring.GetOwners(key, _options.ReplicationFactor);
+    public bool IsLocalOwner(string key) => GetOwners(key).Any(n => string.Equals(n.NodeId, _options.LocalNodeId, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/Caching.Framework/Distributed/DistributedCacheOptions.cs
+++ b/src/Caching.Framework/Distributed/DistributedCacheOptions.cs
@@ -1,0 +1,8 @@
+namespace Caching.Framework.Distributed;
+
+public sealed class DistributedCacheOptions
+{
+    public string LocalNodeId { get; set; } = Environment.MachineName;
+    public int ReplicationFactor { get; set; } = 1;
+    public List<CacheNode> Nodes { get; set; } = [];
+}

--- a/src/Caching.Framework/Distributed/RendezvousHashRing.cs
+++ b/src/Caching.Framework/Distributed/RendezvousHashRing.cs
@@ -1,0 +1,40 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Caching.Framework.Distributed;
+
+/// <summary>Chooses stable cache owners with highest-random-weight rendezvous hashing.</summary>
+public sealed class RendezvousHashRing
+{
+    private readonly IReadOnlyList<CacheNode> _nodes;
+
+    public RendezvousHashRing(IEnumerable<CacheNode> nodes)
+    {
+        _nodes = nodes.GroupBy(n => n.NodeId, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .OrderBy(n => n.NodeId, StringComparer.Ordinal)
+            .ToArray();
+
+        if (_nodes.Count == 0)
+        {
+            throw new InvalidOperationException("At least one cache node is required.");
+        }
+    }
+
+    public IReadOnlyList<CacheNode> GetOwners(string key, int replicas = 1)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var take = Math.Clamp(replicas, 1, _nodes.Count);
+        return _nodes.Select(node => new { Node = node, Score = Score(node.NodeId, key) })
+            .OrderByDescending(x => x.Score)
+            .Take(take)
+            .Select(x => x.Node)
+            .ToArray();
+    }
+
+    private static ulong Score(string nodeId, string key)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes($"{nodeId}:{key}"));
+        return BitConverter.ToUInt64(bytes, 0);
+    }
+}

--- a/src/Caching.Framework/Memory/MemoryCacheClient.cs
+++ b/src/Caching.Framework/Memory/MemoryCacheClient.cs
@@ -1,0 +1,56 @@
+using Caching.Framework.Abstractions;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Caching.Framework.Memory;
+
+/// <summary>Thread-safe in-process cache client backed by <see cref="IMemoryCache" />.</summary>
+public sealed class MemoryCacheClient(IMemoryCache memoryCache) : ICacheClient
+{
+    public Task SetAsync<T>(string key, T value, CacheEntryOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        options ??= CacheEntryOptions.NeverExpire;
+        var expiresAt = options.TimeToLive is { } ttl ? DateTimeOffset.UtcNow.Add(ttl) : (DateTimeOffset?)null;
+        var entry = new CacheItem<T>(key, value, expiresAt, options.Region);
+        var memoryOptions = new MemoryCacheEntryOptions();
+        if (options.TimeToLive is { } timeToLive)
+        {
+            memoryOptions.AbsoluteExpirationRelativeToNow = timeToLive;
+        }
+
+        memoryCache.Set(BuildKey(key, options.Region), entry, memoryOptions);
+        return Task.CompletedTask;
+    }
+
+    public Task<CacheItem<T>?> GetAsync<T>(string key, string? region = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(memoryCache.TryGetValue<CacheItem<T>>(BuildKey(key, region), out var item) ? item : null);
+    }
+
+    public async Task<T> GetOrCreateAsync<T>(string key, Func<CancellationToken, Task<T>> factory, CacheEntryOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var cached = await GetAsync<T>(key, options?.Region, cancellationToken);
+        if (cached is not null)
+        {
+            return cached.Value;
+        }
+
+        var value = await factory(cancellationToken);
+        await SetAsync(key, value, options, cancellationToken);
+        return value;
+    }
+
+    public Task<bool> RemoveAsync(string key, string? region = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        cancellationToken.ThrowIfCancellationRequested();
+        memoryCache.Remove(BuildKey(key, region));
+        return Task.FromResult(true);
+    }
+
+    private static string BuildKey(string key, string? region) => string.IsNullOrWhiteSpace(region) ? key : $"{region}:{key}";
+}

--- a/tests/Caching.Framework.Tests/Caching.Framework.Tests.csproj
+++ b/tests/Caching.Framework.Tests/Caching.Framework.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Caching.Framework\Caching.Framework.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Caching.Framework.Tests/MemoryCacheClientTests.cs
+++ b/tests/Caching.Framework.Tests/MemoryCacheClientTests.cs
@@ -1,0 +1,34 @@
+using Caching.Framework.Abstractions;
+using Caching.Framework.Memory;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Caching.Framework.Tests;
+
+public sealed class MemoryCacheClientTests
+{
+    [Fact]
+    public async Task GetOrCreateCachesFactoryResult()
+    {
+        var client = new MemoryCacheClient(new MemoryCache(new MemoryCacheOptions()));
+        var calls = 0;
+
+        var first = await client.GetOrCreateAsync("customer:42", _ => Task.FromResult(++calls), CacheEntryOptions.WithTtl(TimeSpan.FromMinutes(5)));
+        var second = await client.GetOrCreateAsync("customer:42", _ => Task.FromResult(++calls), CacheEntryOptions.WithTtl(TimeSpan.FromMinutes(5)));
+
+        Assert.Equal(1, first);
+        Assert.Equal(1, second);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task RegionSeparatesKeys()
+    {
+        var client = new MemoryCacheClient(new MemoryCache(new MemoryCacheOptions()));
+
+        await client.SetAsync("settings", "tenant-a", new CacheEntryOptions { Region = "a" });
+        await client.SetAsync("settings", "tenant-b", new CacheEntryOptions { Region = "b" });
+
+        Assert.Equal("tenant-a", (await client.GetAsync<string>("settings", "a"))?.Value);
+        Assert.Equal("tenant-b", (await client.GetAsync<string>("settings", "b"))?.Value);
+    }
+}

--- a/tests/Caching.Framework.Tests/RendezvousHashRingTests.cs
+++ b/tests/Caching.Framework.Tests/RendezvousHashRingTests.cs
@@ -1,0 +1,35 @@
+using Caching.Framework.Distributed;
+
+namespace Caching.Framework.Tests;
+
+public sealed class RendezvousHashRingTests
+{
+    private static readonly CacheNode[] Nodes =
+    [
+        new("node-a", new Uri("http://node-a")),
+        new("node-b", new Uri("http://node-b")),
+        new("node-c", new Uri("http://node-c"))
+    ];
+
+    [Fact]
+    public void SameKeyReturnsStablePlacement()
+    {
+        var ring = new RendezvousHashRing(Nodes);
+
+        var first = ring.GetOwners("user:42", 2).Select(x => x.NodeId).ToArray();
+        var second = ring.GetOwners("user:42", 2).Select(x => x.NodeId).ToArray();
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void PlacementHonorsReplicaCount()
+    {
+        var ring = new RendezvousHashRing(Nodes);
+
+        var owners = ring.GetOwners("order:100", 2);
+
+        Assert.Equal(2, owners.Count);
+        Assert.Equal(owners.Select(x => x.NodeId).Distinct().Count(), owners.Count);
+    }
+}

--- a/tests/Caching.Framework.Tests/Usings.cs
+++ b/tests/Caching.Framework.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;


### PR DESCRIPTION
### Motivation
- Turn the repository into a reusable, packable caching framework that can be distributed and extended with provider implementations and commercial packaging.
- Provide small, well-scoped public abstractions and primitives for cache-aside workflows, in-process storage, and distributed rendezvous-hash placement so downstream products can implement additional providers.

### Description
- Add a new `Caching.Framework` class library with NuGet metadata at `src/Caching.Framework/Caching.Framework.csproj` and include it in the solution file so it can be built/packed.
- Introduce public abstractions in `Caching.Framework.Abstractions` including `ICacheClient`, `CacheItem<T>`, and `CacheEntryOptions` for TTL and region support.
- Implement an in-process provider `MemoryCacheClient` in `src/Caching.Framework/Memory` with TTL, region-aware keys, `GetOrCreateAsync` (cache-aside), and `RemoveAsync` backed by `IMemoryCache`.
- Add distributed placement primitives in `src/Caching.Framework/Distributed` including `CacheNode`, `DistributedCacheOptions`, `CachePlacementService`, and `RendezvousHashRing` for deterministic owner selection.
- Add DI registration helper `AddCachingFramework` in `src/Caching.Framework/DependencyInjection` and update `README.md` to document usage, packaging, and a commercial hardening roadmap.
- Add focused unit tests under `tests/Caching.Framework.Tests` covering cache-aside behavior, region separation, and rendezvous hashing deterministic placement.

### Testing
- Unit tests were added (`tests/Caching.Framework.Tests`) to validate `MemoryCacheClient` behavior and `RendezvousHashRing` placement, but they were not executed in this environment.
- No automated test run was performed here because `dotnet` is not available; to run locally use `dotnet build` and `dotnet test` against the solution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34ab17c0e48324875a1135ef281acf)