### PR TITLE
Add product branding constants

### DIFF
--- a/MARKET_READY_TODO.md
+++ b/MARKET_READY_TODO.md
@@ -4,13 +4,13 @@ This checklist breaks market-readiness work into very small, concrete tasks. Pre
 
 ## Product identity and package metadata
 
-- [ ] Create `src/Caching.Framework/Branding/ProductBrand.cs`.
-- [ ] Add a `public const string Name = "Caching.Framework"` field to `ProductBrand`.
-- [ ] Add a `public const string DisplayName = "Caching Framework"` field to `ProductBrand`.
-- [ ] Add a `public const string Tagline` field to `ProductBrand`.
-- [ ] Add a `public const string WebsiteUrl` field to `ProductBrand`.
-- [ ] Add a `public const string DocumentationUrl` field to `ProductBrand`.
-- [ ] Add a `public const string SupportUrl` field to `ProductBrand`.
+- [x] Create `src/Caching.Framework/Branding/ProductBrand.cs`.
+- [x] Add a `public const string Name = "Caching.Framework"` field to `ProductBrand`.
+- [x] Add a `public const string DisplayName = "Caching Framework"` field to `ProductBrand`.
+- [x] Add a `public const string Tagline` field to `ProductBrand`.
+- [x] Add a `public const string WebsiteUrl` field to `ProductBrand`.
+- [x] Add a `public const string DocumentationUrl` field to `ProductBrand`.
+- [x] Add a `public const string SupportUrl` field to `ProductBrand`.
 - [ ] Add a unit test named `ProductBrand_HasNonEmptyDisplayName`.
 - [ ] Add a unit test named `ProductBrand_HasNonEmptyTagline`.
 - [ ] Update `src/Caching.Framework/Caching.Framework.csproj` with a final `PackageProjectUrl` value.

--- a/src/Caching.Framework/Branding/ProductBrand.cs
+++ b/src/Caching.Framework/Branding/ProductBrand.cs
@@ -1,0 +1,25 @@
+namespace Caching.Framework.Branding;
+
+/// <summary>
+/// Defines public product identity values for Caching Framework.
+/// </summary>
+public static class ProductBrand
+{
+    /// <summary>The product package and assembly identity.</summary>
+    public const string Name = "Caching.Framework";
+
+    /// <summary>The human-readable product name.</summary>
+    public const string DisplayName = "Caching Framework";
+
+    /// <summary>A short product description suitable for marketing surfaces.</summary>
+    public const string Tagline = "A composable .NET caching framework for fast, resilient applications.";
+
+    /// <summary>The main product website URL.</summary>
+    public const string WebsiteUrl = "https://github.com/caching-framework/caching";
+
+    /// <summary>The product documentation URL.</summary>
+    public const string DocumentationUrl = "https://github.com/caching-framework/caching/tree/main/docs";
+
+    /// <summary>The product support URL.</summary>
+    public const string SupportUrl = "https://github.com/caching-framework/caching/issues";
+}


### PR DESCRIPTION
### Motivation
- Provide a single, discoverable source of product identity values for the package and to satisfy the market-readiness checklist items.

### Description
- Created `src/Caching.Framework/Branding/ProductBrand.cs` and added public constants `Name`, `DisplayName`, `Tagline`, `WebsiteUrl`, `DocumentationUrl`, and `SupportUrl`.
- Marked the corresponding product-branding items as completed in `MARKET_READY_TODO.md`.

### Testing
- Attempted to run `dotnet test Caching.sln`, but the command could not run because `dotnet` is not installed in the environment.
- No unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a365b8a3a188324a862262ccc3dcdac)