### PR TITLE
Set `PackageProjectUrl` in Caching.Framework.csproj and update checklist

### DIFF
--- a/MARKET_READY_TODO.md
+++ b/MARKET_READY_TODO.md
@@ -13,7 +13,7 @@ This checklist breaks market-readiness work into very small, concrete tasks. Pre
 - [x] Add a `public const string SupportUrl` field to `ProductBrand`.
 - [ ] Add a unit test named `ProductBrand_HasNonEmptyDisplayName`.
 - [ ] Add a unit test named `ProductBrand_HasNonEmptyTagline`.
-- [ ] Update `src/Caching.Framework/Caching.Framework.csproj` with a final `PackageProjectUrl` value.
+- [x] Update `src/Caching.Framework/Caching.Framework.csproj` with a final `PackageProjectUrl` value.
 - [ ] Update `src/Caching.Framework/Caching.Framework.csproj` with a final `RepositoryUrl` value.
 - [ ] Update `src/Caching.Framework/Caching.Framework.csproj` with `PackageTags`.
 - [ ] Update `src/Caching.Framework/Caching.Framework.csproj` with `PackageIcon`.

--- a/src/Caching.Framework/Caching.Framework.csproj
+++ b/src/Caching.Framework/Caching.Framework.csproj
@@ -6,6 +6,7 @@
     <Description>A composable .NET caching framework with in-memory storage, cache-aside helpers, and distributed rendezvous-hash placement.</Description>
     <Authors>Caching Framework Contributors</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/caching-framework/caching</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
### Motivation
- Finalize package metadata by providing a concrete project URL so the NuGet package has a valid `PackageProjectUrl` entry.

### Description
- Add `<PackageProjectUrl>https://github.com/caching-framework/caching</PackageProjectUrl>` to `src/Caching.Framework/Caching.Framework.csproj` and mark the corresponding item in `MARKET_READY_TODO.md` as completed.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36883372f08324bdbfebda0737cf30)